### PR TITLE
fix: grabbable object unhighlights when locked after step

### DIFF
--- a/Runtime/Properties/TouchableProperty.cs
+++ b/Runtime/Properties/TouchableProperty.cs
@@ -115,6 +115,8 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
                 {
                     interactable.ForceStopInteracting();
                 }
+                
+                interactable.enabled = lockState == false;
 
                 if (highlighter != null && highlighter.touchHighlight != Color.clear)
                 {
@@ -128,8 +130,6 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
                     }
                 }
             }
-
-            interactable.enabled = lockState == false;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description
Grabbable object was still highlighted in the next step after it was locked.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manual testing by creating a step which has a GrabbedCondition. When object is grabbed it will be forcefully locked in the next step and therefore should not be highlighted anymore.


### Checklist
- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules