### PR TITLE
fix: fixed possible npe when properties start disabled

### DIFF
--- a/Runtime/Properties/GrabbableProperty.cs
+++ b/Runtime/Properties/GrabbableProperty.cs
@@ -24,26 +24,36 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         {
             get
             {
-                if (interactable != null)
+                if (Interactable != null)
                 {
-                    return interactable.IsGrabbed();
+                    return Interactable.IsGrabbed();
                 }
                 return false;
             }
         }
 
-        private VRTK_InteractableObject interactable;
+        private VRTK_InteractableObject interactable = null;
+        private VRTK_InteractableObject Interactable
+        {
+            get
+            {
+                if (interactable == null)
+                {
+                    interactable = gameObject.GetComponent<VRTK_InteractableObject>();
+                    if (interactable == null)
+                    {
+                        interactable = gameObject.AddComponent<InteractableObject>();
+                    }
+                }
+
+                return interactable;
+            }
+        }
         private VRTK_InteractObjectHighlighter highlighter;
 
         protected override void OnEnable()
         {
             base.OnEnable();
-
-            interactable = gameObject.GetComponent<VRTK_InteractableObject>();
-            if (interactable == null)
-            {
-                interactable = gameObject.AddComponent<InteractableObject>();
-            }
 
             if (gameObject.GetComponent<VRTK_BaseHighlighter>() == null)
             {
@@ -58,23 +68,25 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
                 grab.precisionGrab = true;
             }
 
-            interactable.isGrabbable = true;
+            Interactable.isGrabbable = true;
 
-            interactable.InteractableObjectGrabbed += HandleVRTKGrabbed;
-            interactable.InteractableObjectUngrabbed += HandleVRTKUngrabbed;
+            Interactable.InteractableObjectGrabbed += HandleVRTKGrabbed;
+            Interactable.InteractableObjectUngrabbed += HandleVRTKUngrabbed;
+
+            InternalSetLocked(IsLocked);
         }
 
         protected override void OnDisable()
         {
             base.OnDisable();
 
-            if (interactable == null)
+            if (Interactable == null)
             {
                 return;
             }
 
-            interactable.InteractableObjectGrabbed -= HandleVRTKGrabbed;
-            interactable.InteractableObjectUngrabbed -= HandleVRTKUngrabbed;
+            Interactable.InteractableObjectGrabbed -= HandleVRTKGrabbed;
+            Interactable.InteractableObjectUngrabbed -= HandleVRTKUngrabbed;
         }
 
         private void HandleVRTKGrabbed(object sender, InteractableObjectEventArgs args)
@@ -99,11 +111,11 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
 
         protected override void InternalSetLocked(bool lockState)
         {
-            if (interactable.IsGrabbed())
+            if (Interactable.IsGrabbed())
             {
                 if (lockState)
                 {
-                    interactable.ForceStopInteracting();
+                    Interactable.ForceStopInteracting();
                 }
 
                 if (highlighter == null)
@@ -124,7 +136,7 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
                 }
             }
 
-            interactable.isGrabbable = lockState == false;
+            Interactable.isGrabbable = lockState == false;
         }
 
         /// <summary>
@@ -132,12 +144,12 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         /// </summary>
         public void FastForwardGrab()
         {
-            if (interactable.IsGrabbed())
+            if (Interactable.IsGrabbed())
             {
-                VRTK_InteractGrab grab = interactable.GetGrabbingObject().GetComponent<VRTK_InteractGrab>();
-                interactable.Ungrabbed();
+                VRTK_InteractGrab grab = Interactable.GetGrabbingObject().GetComponent<VRTK_InteractGrab>();
+                Interactable.Ungrabbed();
                 grab.AttemptGrab();
-                interactable.ForceStopInteracting();
+                Interactable.ForceStopInteracting();
             }
             else
             {
@@ -146,15 +158,14 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
             }
         }
 
-
         /// <summary>
         /// Instantaneously simulate that the object was ungrabbed.
         /// </summary>
         public void FastForwardUngrab()
         {
-            if (interactable.IsGrabbed())
+            if (Interactable.IsGrabbed())
             {
-                interactable.ForceStopInteracting();
+                Interactable.ForceStopInteracting();
             }
             else
             {

--- a/Runtime/Properties/SnapZoneProperty.cs
+++ b/Runtime/Properties/SnapZoneProperty.cs
@@ -43,7 +43,19 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
             }
         }
 
-        public SnapDropZone SnapZone { get; protected set; }
+        private SnapDropZone snapZone = null;
+        public SnapDropZone SnapZone
+        {
+            get
+            {
+                if (snapZone == null)
+                {
+                    snapZone = GetComponent<SnapDropZone>();
+                }
+
+                return snapZone;
+            }
+        }
 
         public void Configure(IMode mode)
         {
@@ -73,6 +85,8 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
 
             SnapZone.ObjectSnappedToDropZone += HandleObjectSnapped;
             SnapZone.ObjectUnsnappedFromDropZone += HandleObjectUnsnapped;
+            
+            InternalSetLocked(IsLocked);
         }
 
         protected override void OnDisable()
@@ -106,11 +120,6 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
 
         private void InitializeModeParameters()
         {
-            if (SnapZone == null)
-            {
-                SnapZone = GetComponent<SnapDropZone>();
-            }
-
             if (IsShowingHighlight == null)
             {
                 highlightPrefab = SnapZone.highlightObjectPrefab;

--- a/Runtime/Properties/TouchableProperty.cs
+++ b/Runtime/Properties/TouchableProperty.cs
@@ -21,9 +21,9 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         {
             get
             {
-                if (interactable != null)
+                if (Interactable != null)
                 {
-                    return interactable.IsTouched();
+                    return Interactable.IsTouched();
                 }
 
                 return false;
@@ -33,25 +33,42 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         public bool UsableOnlyIfGrabbed { get; protected set; }
         public bool HoldButtonToUse { get; protected set; }
 
-        protected VRTK_InteractableObject interactable;
+        private VRTK_InteractableObject interactable;
+
+        protected VRTK_InteractableObject Interactable
+        {
+            get
+            {
+                if (interactable == null)
+                {
+                    interactable = gameObject.GetComponent<VRTK_InteractableObject>();
+                    if (interactable == null)
+                    {
+                        interactable = gameObject.AddComponent<InteractableObject>();
+                    }
+                }
+
+                return interactable;
+            }
+        }
 
         protected VRTK_InteractObjectHighlighter highlighter;
 
         public void SetUsableOnlyIfGrabbed(bool value)
         {
             UsableOnlyIfGrabbed = value;
-            if (interactable != null)
+            if (Interactable != null)
             {
-                interactable.useOnlyIfGrabbed = value;
+                Interactable.useOnlyIfGrabbed = value;
             }
         }
 
         public void SetHoldButtonToUse(bool value)
         {
             HoldButtonToUse = value;
-            if (interactable != null)
+            if (Interactable != null)
             {
-                interactable.holdButtonToUse = value;
+                Interactable.holdButtonToUse = value;
             }
         }
 
@@ -59,17 +76,11 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         {
             base.OnEnable();
 
-            interactable = gameObject.GetComponent<VRTK_InteractableObject>();
-            if (interactable == null)
-            {
-                interactable = gameObject.AddComponent<InteractableObject>();
-            }
+            Interactable.disableWhenIdle = false; // required to allow deactivating interactable object touching
+            Interactable.enabled = true;
 
-            interactable.disableWhenIdle = false; // required to allow deactivating interactable object touching
-            interactable.enabled = true;
-
-            interactable.InteractableObjectTouched += HandleVRTKTouched;
-            interactable.InteractableObjectUntouched += HandleVRTKUntouched;
+            Interactable.InteractableObjectTouched += HandleVRTKTouched;
+            Interactable.InteractableObjectUntouched += HandleVRTKUntouched;
 
             highlighter = gameObject.GetComponent<VRTK_InteractObjectHighlighter>();
             if (highlighter == null)
@@ -77,14 +88,16 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
                 highlighter = gameObject.AddComponent<VRTK_InteractObjectHighlighter>();
                 highlighter.touchHighlight = new Color(0.259f, 0.7843f, 1.0f, 0.5f);
             }
+            
+            InternalSetLocked(IsLocked);
         }
 
         protected override void OnDisable()
         {
             base.OnDisable();
 
-            interactable.InteractableObjectUsed -= HandleVRTKTouched;
-            interactable.InteractableObjectUnused -= HandleVRTKUntouched;
+            Interactable.InteractableObjectUsed -= HandleVRTKTouched;
+            Interactable.InteractableObjectUnused -= HandleVRTKUntouched;
         }
 
         private void HandleVRTKTouched(object sender, InteractableObjectEventArgs args)
@@ -109,14 +122,15 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
 
         protected override void InternalSetLocked(bool lockState)
         {
-            if (interactable.IsTouched())
+            Interactable.enabled = lockState == false;
+            if (Interactable.IsTouched())
             {
                 if (lockState)
                 {
-                    interactable.ForceStopInteracting();
+                    Interactable.ForceStopInteracting();
                 }
                 
-                interactable.enabled = lockState == false;
+                Interactable.enabled = lockState == false;
 
                 if (highlighter != null && highlighter.touchHighlight != Color.clear)
                 {
@@ -137,11 +151,11 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         /// </summary>
         public void FastForwardTouch()
         {
-            if (interactable.IsTouched())
+            if (Interactable.IsTouched())
             {
-                interactable.StopTouching();
-                interactable.StartTouching();
-                interactable.ForceStopInteracting();
+                Interactable.StopTouching();
+                Interactable.StartTouching();
+                Interactable.ForceStopInteracting();
             }
             else
             {

--- a/Runtime/Properties/UsableProperty.cs
+++ b/Runtime/Properties/UsableProperty.cs
@@ -19,9 +19,9 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         {
             get
             {
-                if (interactable != null)
+                if (Interactable != null)
                 {
-                    return interactable.IsUsing();
+                    return Interactable.IsUsing();
                 }
                 return false;
             }
@@ -35,7 +35,25 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         private bool holdButtonToUse = false;
         public bool HoldButtonToUse { get { return holdButtonToUse; } protected set { holdButtonToUse = value; } }
 
-        protected VRTK_InteractableObject interactable;
+        private VRTK_InteractableObject interactable;
+
+        protected VRTK_InteractableObject Interactable
+        {
+            get
+            {
+                if (interactable == null)
+                {
+                    interactable = gameObject.GetComponent<VRTK_InteractableObject>();
+                    if (interactable == null)
+                    {
+                        interactable = gameObject.AddComponent<InteractableObject>();
+                    }
+                }
+
+                return interactable;
+            }
+        }
+        
         protected VRTK_InteractObjectHighlighter highlighter;
 
         public UsableProperty()
@@ -47,18 +65,18 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         public void SetUsableOnlyIfGrabbed(bool value)
         {
             UsableOnlyIfGrabbed = value;
-            if (interactable != null)
+            if (Interactable != null)
             {
-                interactable.useOnlyIfGrabbed = value;
+                Interactable.useOnlyIfGrabbed = value;
             }
         }
 
         public void SetHoldButtonToUse(bool value)
         {
             HoldButtonToUse = value;
-            if (interactable != null)
+            if (Interactable != null)
             {
-                interactable.holdButtonToUse = value;
+                Interactable.holdButtonToUse = value;
             }
         }
 
@@ -66,29 +84,25 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         {
             base.OnEnable();
 
-            interactable = gameObject.GetComponent<VRTK_InteractableObject>();
-            if (interactable == null)
-            {
-                interactable = gameObject.AddComponent<InteractableObject>();
-            }
+            Interactable.holdButtonToUse = HoldButtonToUse;
+            Interactable.useOnlyIfGrabbed = UsableOnlyIfGrabbed;
 
-            interactable.holdButtonToUse = HoldButtonToUse;
-            interactable.useOnlyIfGrabbed = UsableOnlyIfGrabbed;
+            Interactable.isUsable = true;
 
-            interactable.isUsable = true;
-
-            interactable.InteractableObjectUsed += HandleVRTKUsageStarted;
-            interactable.InteractableObjectUnused += HandleVRTKUsageStopped;
+            Interactable.InteractableObjectUsed += HandleVRTKUsageStarted;
+            Interactable.InteractableObjectUnused += HandleVRTKUsageStopped;
+            
+            InternalSetLocked(IsLocked);
         }
 
         protected override void OnDisable()
         {
             base.OnDisable();
 
-            if (interactable != null)
+            if (Interactable != null)
             {
-                interactable.InteractableObjectUsed -= HandleVRTKUsageStarted;
-                interactable.InteractableObjectUnused -= HandleVRTKUsageStopped;
+                Interactable.InteractableObjectUsed -= HandleVRTKUsageStarted;
+                Interactable.InteractableObjectUnused -= HandleVRTKUsageStopped;
             }
         }
 
@@ -114,11 +128,11 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
 
         protected override void InternalSetLocked(bool lockState)
         {
-            if (interactable.IsUsing())
+            if (Interactable.IsUsing())
             {
                 if (lockState)
                 {
-                    interactable.ForceStopInteracting();
+                    Interactable.ForceStopInteracting();
                 }
 
                 if (highlighter == null)
@@ -138,7 +152,7 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
                     }
                 }
             }
-            interactable.isUsable = lockState == false;
+            Interactable.isUsable = lockState == false;
         }
 
         /// <summary>
@@ -146,12 +160,12 @@ namespace Innoactive.Creator.VRTKInteraction.Properties
         /// </summary>
         public void FastForwardUse()
         {
-            if (interactable.IsUsing())
+            if (Interactable.IsUsing())
             {
-                VRTK_InteractUse user = interactable.GetUsingScript();
-                interactable.StopUsing();
+                VRTK_InteractUse user = Interactable.GetUsingScript();
+                Interactable.StopUsing();
                 user.AttemptUse();
-                interactable.StopUsing();
+                Interactable.StopUsing();
             }
             else
             {


### PR DESCRIPTION
### Description
we only got the reference to the interactable OnEnable which caused a npe when disabled objects where locked. Fixed it by adding a getter which cares about that.